### PR TITLE
added percentile parameter

### DIFF
--- a/imgui_dock.h
+++ b/imgui_dock.h
@@ -22,7 +22,7 @@ namespace ImGui{
 IMGUI_API void BeginDockspace();
 IMGUI_API void EndDockspace();
 IMGUI_API void ShutdownDock();
-IMGUI_API void SetNextDock(ImGuiDockSlot slot);
+IMGUI_API void SetNextDock(ImGuiDockSlot slot, float percentage=0.5f);
 IMGUI_API bool BeginDock(const char* label, bool* opened = NULL, ImGuiWindowFlags extra_flags = 0);
 IMGUI_API void EndDock();
 IMGUI_API void SetDockActive();


### PR DESCRIPTION
Hey, not sure this is the best place to submit a PR on the ongoing "docking for imgui" feature. This seems like the only clean version, not tied into someone else's API. If there's a better spot, please let me know.

Anyways, I wanted to have some control over the placement of docks on startup, as I use this for my whole UI, and dock positioning/size isn't serialized at all. Here's a couple screenshots showing why I had to put this in...

![percentiles out](https://cloud.githubusercontent.com/assets/3078396/18115602/9d1f165e-6f0e-11e6-94da-81aad063675d.JPG)
![percentiles in](https://cloud.githubusercontent.com/assets/3078396/18115603/9d1fb3c0-6f0e-11e6-9df9-ca82bd7eccb0.JPG)

This just adds an optional parameter to the SetNextDock(...) call, defaults to an even split.
